### PR TITLE
Collision updates

### DIFF
--- a/dirt/examples/nomnom/nomnom_env.py
+++ b/dirt/examples/nomnom/nomnom_env.py
@@ -180,45 +180,18 @@ def nomnom(
         given the environment params, a previous state and an action.
         '''
         
+        # TODO: It turns out that the order of operations in this code is
+        # actually somewhat sensitive, especially considering the updates to
+        # the object grid.  It turns out that there are many subtle bugs that
+        # can come up if this is not all handled correctly.  I think an
+        # it would be worthwhile in the near future to to take the components
+        # here and find a way to compartmentalize them further and make a
+        # computational primitive that handles the book-keeping of not only
+        # the list of active players, but their positions, rotations and
+        # the object_grid.
+        
+        # get the active players
         active_players = active_family_tree(state.family_tree)
-        
-        
-        #######################3
-        tmp_object_grid = dynamics.make_object_grid(
-            params.world_size, state.player_x, active_players)
-        
-        def print_stuff():
-            jax.debug.print('BAD THING MAN')
-            jax.debug.print('ACTIVE! {a}', a=active_players)
-            jax.debug.print('X {x}', x=state.player_x)
-        
-        correct = jnp.all(tmp_object_grid == state.object_grid)
-        jax.lax.cond(correct, lambda: None, print_stuff)
-        
-        
-        
-        
-        # check accurate pre object grid==========================
-        recorded_spots = state.object_grid[state.player_x[...,0], state.player_x[...,1]]
-        n = state.player_x.shape[0]
-        accurate_og = (
-            recorded_spots == jnp.arange(n)) | ~active_players
-        def print_info():
-            jax.debug.print('BAD PRE SETUP')
-            jax.debug.print('recorded {r}', r=recorded_spots)
-            jax.debug.print('accurate_og {a}', a=accurate_og)
-            jax.debug.print('active {a}', a=active_players)
-            jax.debug.print('object grid {og}', og=state.object_grid)
-            jax.debug.print('player_x {x}', x=state.player_x)
-        
-        jax.lax.cond(jnp.any(~accurate_og),
-            print_info,
-            lambda : None,
-        )
-        
-        
-        
-        
         
         # move
         player_x, player_r, _, object_grid = dynamics.forward_rotate_step(
@@ -230,51 +203,6 @@ def nomnom(
             check_collisions=True,
             object_grid=state.object_grid,
         )
-        
-        
-        # check accurate object grid==========================
-        recorded_spots = object_grid[player_x[...,0], player_x[...,1]]
-        n = player_x.shape[0]
-        accurate_og = (
-            recorded_spots == jnp.arange(n)) | ~active_players
-        def print_info():
-            jax.debug.print('BAD SETUP')
-            jax.debug.print('recorded {r}', r=recorded_spots)
-            jax.debug.print('accurate_og {a}', a=accurate_og)
-            jax.debug.print('active {a}', a=active_players)
-            jax.debug.print('pre object grid {og}', og=state.object_grid)
-            jax.debug.print('object grid {og}', og=object_grid)
-            jax.debug.print('pre player_x {x}', x=state.player_x)
-            jax.debug.print('player_x {x}', x=player_x)
-            jax.debug.print('forward {f}', f=action.forward)
-        
-        jax.lax.cond(jnp.any(~accurate_og),
-            print_info,
-            lambda : None,
-        )
-        
-        
-        
-        
-        overlapping = player_x[None] == player_x[:,None]
-        overlapping = overlapping[:,:,0] * overlapping[:,:,1]
-        overlapping = overlapping & active_players[:,None]
-        overlapping = overlapping & active_players
-        overlapping = overlapping & ~jnp.eye(active_players.shape[0], dtype=jnp.bool)
-        i,j = jnp.nonzero(overlapping, size=active_players.shape[0], fill_value=-1)
-        jax.lax.cond(jnp.any(overlapping),
-            lambda : jax.debug.print('overlapping after dynamics'),
-            #lambda : jax.debug.print('not overlapping after dynamics'),
-            lambda : None,
-        )
-        #jax.debug.print('ad {i} {j}', i=i, j=j)
-        #jax.debug.print('ad {p}', p=player_x[i][:4])
-        #jax.debug.print('x0 {x}', x=state.player_x[i][:4])
-        #jax.debug.print('x1 {x}', x=player_x[i][:4])
-        
-        
-        
-        
         
         # eat
         # - figure out who will eat which food
@@ -297,13 +225,8 @@ def nomnom(
             moved * params.move_metabolism +
             (1. - moved) * params.wait_metabolism
         ) * active_players
-    
-        # kill players that have starved
-        deaths = player_energy <= 0.
 
-        # update the object grid to account for dead players
-
-        # make new players based on reproduction
+        # update the players based on starvation and reproduction
         # - filter the reproduce vector to remove dead players and those without
         #   enough energy to create offspring
         reproduce = (
@@ -319,6 +242,9 @@ def nomnom(
             player_r,
             object_grid=object_grid,
         )
+    
+        # - kill players that have starved
+        deaths = player_energy <= 0.
         
         # - use reproduce to make new child ids and update the player data
         n = reproduce.shape[0]
@@ -327,84 +253,33 @@ def nomnom(
         family_tree, child_locations = step_family_tree(
             state.family_tree, deaths, parent_locations)
         
+        # - reorder child_x and child_r to be aligned with the parent
+        #   and child locations
         child_x = child_x[parent_locations[...,0]]
         child_r = child_r[parent_locations[...,0]]
         
-        # update the object grid, player_x and player_r
-        # this needs to happen before the positions are updated
-        pre_object_grid = object_grid
+        # update the object grid, player positions and rotations based on deaths
+        # - update the object grid before the positions
         object_grid = object_grid.at[player_x[...,0], player_x[...,1]].set(
             jnp.where(deaths, -1, jnp.arange(n)))
+        # - then update the positions and rotations
         player_x = jnp.where(
             deaths[:,None],
             jnp.array(params.world_size, dtype=jnp.int32),
             player_x,
         )
         player_r = jnp.where(deaths, 0, player_r)
-        mid_object_grid = object_grid
+        
+        # update the object grid, player positions, rotation and energy based on
+        # new children
         object_grid = object_grid.at[child_x[...,0], child_x[...,1]].set(
             child_locations)
-        
-        # update the player positions, rotation and energy
         player_x = player_x.at[child_locations].set(child_x)
         player_r = player_r.at[child_locations].set(child_r)
         player_energy = player_energy.at[parent_locations].add(
             -params.initial_energy)
         player_energy = player_energy.at[child_locations].set(
             params.initial_energy)
-        
-        ################################3
-        tmp_active = active_family_tree(family_tree)
-        tmp_object_grid = dynamics.make_object_grid(
-            params.world_size, player_x, tmp_active)
-        
-        
-        
-        
-        
-        correct_update = jnp.all(tmp_object_grid == object_grid)
-        def print_stuff():
-            jax.debug.print('deaths {d}', d=deaths)
-            jax.debug.print('child_locations {c}', c=child_locations)
-            jax.debug.print('player_x {x}', x=player_x)
-            jax.debug.print('child_x {x}', x=child_x)
-            jax.debug.print('POG {h}', h=pre_object_grid)
-            jax.debug.print('MOG {h}', h=mid_object_grid)
-            jax.debug.print('TOG {h}', h=tmp_object_grid)
-            jax.debug.print('OG {h}', h=object_grid)
-            jax.debug.print('ACT {a}', a=tmp_active)
-            jax.debug.print('X {x}', x=player_x)
-        
-        jax.lax.cond(correct_update, lambda: None, print_stuff)
-        
-        
-        
-        
-        
-        active_players = active_family_tree(family_tree)
-        #jax.debug.print('re ap {ap}', ap=jnp.sum(active_players))
-        
-        overlapping = player_x[None] == player_x[:,None]
-        overlapping = overlapping[:,:,0] * overlapping[:,:,1]
-        overlapping = overlapping & active_players[:,None]
-        overlapping = overlapping & active_players
-        overlapping = overlapping & ~jnp.eye(active_players.shape[0], dtype=jnp.bool)
-        i,j = jnp.nonzero(overlapping, size=active_players.shape[0], fill_value=-1)
-        def print_overlapping():
-            jax.debug.print('overlapping after reproduce')
-            jax.debug.print('child_locations {c}', c=child_locations)
-            
-        jax.lax.cond(jnp.any(overlapping),
-            print_overlapping,
-            #lambda : jax.debug.print('not overlapping after reproduce'),
-            lambda : None
-        )
-        #jax.debug.print('re {i} {j}', i=i, j=j)
-        #jax.debug.print('re {p}', p=player_x[i][:4])
-        
-        
-        
-        
         
         # grow new food
         key, food_key = jrng.split(key)

--- a/dirt/examples/nomnom/nomnom_env.py
+++ b/dirt/examples/nomnom/nomnom_env.py
@@ -283,12 +283,13 @@ def nomnom(
         
         # grow new food
         key, food_key = jrng.split(key)
-        food_grid = food_grid | spawn.poisson_grid(
+        new_food = spawn.poisson_grid(
             food_key,
             params.mean_food_growth,
             params.max_food_growth,
             params.world_size,
         )
+        food_grid = food_grid | new_food
 
         # compute new state
         state = NomNomState(

--- a/dirt/examples/nomnom/train_nomnom.py
+++ b/dirt/examples/nomnom/train_nomnom.py
@@ -171,15 +171,15 @@ if __name__ == '__main__':
     
     key = jrng.key(5432)
     
-    max_players = 8
+    max_players = 64
     env_params = NomNomParams(
-        mean_initial_food=8**2,
-        max_initial_food=32**2,
-        mean_food_growth=2**2,
-        max_food_growth=16**2,
+        mean_initial_food=1000, #8**2,
+        max_initial_food=1000, #32**2,
+        mean_food_growth=1, #2**2,
+        max_food_growth=1000, #16**2,
         initial_players=8,
         max_players=max_players,
-        world_size=(32,32)
+        world_size=(8,8)
     )
     train_params = NaturalSelectionParams(
         max_population=max_players,
@@ -187,7 +187,7 @@ if __name__ == '__main__':
     params = NomNomTrainParams(
         env_params=env_params,
         train_params=train_params,
-        epochs=10,
+        epochs=5,
         steps_per_epoch=256,
     )
     
@@ -196,5 +196,5 @@ if __name__ == '__main__':
     params.add_commandline_args(parser)
     args = parser.parse_args()
     params = params.from_commandline_args(args)
-
+    
     train(key, params)

--- a/dirt/gridworld2d/spawn.py
+++ b/dirt/gridworld2d/spawn.py
@@ -197,7 +197,7 @@ def spawn_from_parents(
     Generate new child positions (child_x) and rotations (child_r) based on
     local offsets from a single parent.  If given a world_size or object_grid
     this will also check to make sure new children are in bounds and do not
-    collide with another object.  If an object_grid is provided, an updated
+    collide with another object or other new children.
     '''
     
     if object_grid is not None:
@@ -226,8 +226,12 @@ def spawn_from_parents(
     
     # - second make sure the children will not be on top of any existing objects
     if object_grid is not None:
-        child_colliders = object_grid[child_x[:,0], child_x[:,1]]
-        valid_children = valid_children & (child_colliders == empty)
+        #child_colliders = object_grid[child_x[:,0], child_x[:,1]]
+        #valid_children = valid_children & (child_colliders == empty)
+        occupancy_map = (object_grid != empty).astype(jnp.int32)
+        occupancy_map = occupancy_map.at[child_x[:,0], child_x[:,1]].add(1)
+        child_occupancy = occupancy_map[child_x[:,0], child_x[:,1]]
+        valid_children = valid_children & (child_occupancy <= 1)
     
     # update the non-reproduced child_x locations to be off the grid so they
     # don't overwrite important values in the object array

--- a/dirt/gridworld2d/spawn.py
+++ b/dirt/gridworld2d/spawn.py
@@ -225,6 +225,7 @@ def spawn_from_parents(
         valid_children = valid_children & inbounds
     
     # - second make sure the children will not be on top of any existing objects
+    #   or on top of each other
     if object_grid is not None:
         #child_colliders = object_grid[child_x[:,0], child_x[:,1]]
         #valid_children = valid_children & (child_colliders == empty)

--- a/dirt/gridworld2d/spawn.py
+++ b/dirt/gridworld2d/spawn.py
@@ -171,11 +171,12 @@ def poisson_grid(
         spawn locations.
     max_n : The maximum number of new spawn locations to add.
     '''
-    key, subkey = jrng.split(key)
-    spawn = poisson_vector(subkey, mean_n, max_n)
+    key, poisson_key = jrng.split(key)
+    spawn = poisson_vector(poisson_key, mean_n, max_n)
     
-    key, subkey = jrng.split(key)
-    x = uniform_x(subkey, max_n, world_size)
+    key, uniform_key = jrng.split(key)
+    x = uniform_x(uniform_key, max_n, world_size)
+    x = jnp.where(spawn[:,None], x, jnp.array(world_size, dtype=jnp.int32))
     
     grid = jnp.zeros(world_size, dtype=jnp.bool)
     grid = grid.at[x[...,0], x[...,1]].set(spawn)

--- a/dirt/gridworld2d/spawn.py
+++ b/dirt/gridworld2d/spawn.py
@@ -123,32 +123,33 @@ def uniform_r(
         maxval=4,
     )
 
-def uniform_xr(
-    key : chex.PRNGKey,
-    n : int,
-    world_size : Tuple[int, int],
-) -> Tuple[jnp.ndarray, jnp.ndarray] :
-    '''
-    A convenience function that calls both uniform_x and uniform_r with the same
-    set of parameters.
-    
-    When used in a jit compiled program, n must come from a static variable
-    as it controls the shape of a new array.
-    
-    key : Jax RNG key.
-    world_size : Shape to sample positions from.
-    n : The number of positions to sample.
-    '''
-    key, x_key = jrng.split(key)
-    x = uniform_x(x_key, n, world_size)
-    key, r_key = jrng.split(key)
-    r = uniform_r(r_key, n)
-    return x, r
+#def uniform_xr(
+#    key : chex.PRNGKey,
+#    n : int,
+#    world_size : Tuple[int, int],
+#) -> Tuple[jnp.ndarray, jnp.ndarray] :
+#    '''
+#    A convenience function that calls both uniform_x and uniform_r with the same
+#    set of parameters.
+#    
+#    When used in a jit compiled program, n must come from a static variable
+#    as it controls the shape of a new array.
+#    
+#    key : Jax RNG key.
+#    world_size : Shape to sample positions from.
+#    n : The number of positions to sample.
+#    '''
+#    key, x_key = jrng.split(key)
+#    x = uniform_x(x_key, n, world_size)
+#    key, r_key = jrng.split(key)
+#    r = uniform_r(r_key, n)
+#    return x, r
 
 def unique_xr(
     key : chex.PRNGKey,
     n : int,
     world_size : Tuple[int, int],
+    active : Optional[int] = None,
     cell_size : Optional[Tuple[int, int]] = None,
 ) -> Tuple[jnp.ndarray, jnp.ndarray] :
     '''
@@ -166,6 +167,10 @@ def unique_xr(
     key, x_key, r_key = jrng.split(key, 3)
     x = unique_x(x_key, n, world_size, cell_size=cell_size)
     r = uniform_r(r_key, n=n)
+    if active is not None:
+        x = jnp.where(
+            active[:,None], x, jnp.array(world_size, dtype=jnp.int32))
+        r = jnp.where(active, r, 0)
     return x, r
 
 def poisson_grid(

--- a/dirt/gridworld2d/spawn.py
+++ b/dirt/gridworld2d/spawn.py
@@ -123,28 +123,6 @@ def uniform_r(
         maxval=4,
     )
 
-#def uniform_xr(
-#    key : chex.PRNGKey,
-#    n : int,
-#    world_size : Tuple[int, int],
-#) -> Tuple[jnp.ndarray, jnp.ndarray] :
-#    '''
-#    A convenience function that calls both uniform_x and uniform_r with the same
-#    set of parameters.
-#    
-#    When used in a jit compiled program, n must come from a static variable
-#    as it controls the shape of a new array.
-#    
-#    key : Jax RNG key.
-#    world_size : Shape to sample positions from.
-#    n : The number of positions to sample.
-#    '''
-#    key, x_key = jrng.split(key)
-#    x = uniform_x(x_key, n, world_size)
-#    key, r_key = jrng.split(key)
-#    r = uniform_r(r_key, n)
-#    return x, r
-
 def unique_xr(
     key : chex.PRNGKey,
     n : int,


### PR DESCRIPTION
There were a bunch of edge-case bugs that allowed multiple agents to end up in the same grid cell caused by things such as:
- Improper updating/tracking the object grid
- Non-active agents had positions inside the grid which could cause items to be overwritten in the object grid
- Two new children being born into the same location